### PR TITLE
Require dbt-duckdb 1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dbt-duckdb~=1.5.0
+dbt-duckdb~=1.6
 duckcli~=0.2.1
 jafgen~=0.3.1
 pre-commit~=3.0.4


### PR DESCRIPTION
In order to get the `dbt-core` version 1.6 when developing locally, I found I needed to bump the version here. And I needed `dbt-core` 1.6 in order to run the semantic layer, as far as I understand.