### PR TITLE
Fix entity reference in food_order_gross_profit

### DIFF
--- a/models/metrics/fct_orders.yaml
+++ b/models/metrics/fct_orders.yaml
@@ -168,11 +168,11 @@ metrics:
         - name: order_total
           alias: revenue
           filter: |
-            {{Dimension('product__is_food_order')}} = True
+            {{Dimension('order_id__is_food_order')}} = True
         - name: order_amount
           alias: cost
           filter: |
-            {{Dimension('product__is_food_order')}} = True
+            {{Dimension('order_id__is_food_order')}} = True
  #CUMULATIVE METRICS 
   - name: "cumulative_order_amount"
     label: "cumulative_order_amount"    


### PR DESCRIPTION
This was broken - there's no entity named "product" with `is_food_order` present